### PR TITLE
Add practice DebuggingExamples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# launch.json and tasks.json for VSCode
+.vscode/launch.json
+.vscode/tasks.json

--- a/DebuggingExamples/Program.cs
+++ b/DebuggingExamples/Program.cs
@@ -20,12 +20,14 @@ void DisplayPattern()
 {
     var size = 4;
     var message = string.Empty;
-
+    var message2 = string.Empty;
     for (int i = 1; i <= size; i++)
     {
-        PrintMessage(message);
         message += i.ToString();
+        message2 += message + " ";
     }
+    PrintMessage(message2);
+
 }
 
 void PalydromeWords()
@@ -34,7 +36,7 @@ void PalydromeWords()
 
     for (int i = 0; i < names.Count; i++)
     {
-        if (VerifyWord(names[i]))
+        if (VerifyWord(names[i].ToLower()))
         {
             PrintMessage(names[i]);
         }
@@ -79,8 +81,6 @@ List<int> DisplayEvenNumbers()
         {
             evenNumbers.Add(number);
         }
-        return evenNumbers;
     }
-
     return evenNumbers;
 }


### PR DESCRIPTION
1. In the DisplayPattern method, I solved the problem of the empty string at the beginning by moving PrintMessage outside of the for loop and using a variable named message2 to concatenate the previous values with a space.

![2023-01-10_15h50_54](https://user-images.githubusercontent.com/120024162/211657226-7549a218-6e0e-46a1-b8e2-7e3d6c86f2d9.png)

2. In the PalydromeWords() method, to ensure case-insensitivity, I converted the input string to lowercase before passing it to the VerifyWord() method. This eliminates potential issues (Note that 'Reparer' is not a palindrome).

![2023-01-10_16h09_29](https://user-images.githubusercontent.com/120024162/211657889-8c864979-aee8-409a-9fd1-22b4fb1fe708.png)

3. In the PrintNames method, I edited the breakpoint by right-clicking and selecting 'Edit Breakpoint.' I set the condition to trigger when the name is 'Luis'.

![2023-01-10_16h22_22](https://user-images.githubusercontent.com/120024162/211658841-8f318715-bbf6-4f25-bb34-db061681579b.png)


![2023-01-10_16h22_06](https://user-images.githubusercontent.com/120024162/211659308-65359d5b-2843-4990-9a9e-1dc4810fc278.png)

4. In the DisplayEvenNumbers method, I removed the return statement for evenNumbers inside the foreach loop, that's why it was only printing 2.

![2023-01-10_16h29_48](https://user-images.githubusercontent.com/120024162/211659771-2569f85b-1f71-4e65-b643-15d29c7377c1.png)


