### PR TITLE
Test debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+##Debugger
+*.vscode
 # User-specific files
 *.rsuser
 *.suo

--- a/DebuggingExamples/Program.cs
+++ b/DebuggingExamples/Program.cs
@@ -18,7 +18,7 @@ foreach (var number in evenNumbers)
 
 void DisplayPattern()
 {
-    var size = 4;
+    var size = 5;
     var message = string.Empty;
 
     for (int i = 1; i <= size; i++)
@@ -61,7 +61,28 @@ bool VerifyWord(string word)
     var newWord = string.Empty;
     for (int i = word.Length - 1; i > -1; i--)
     {
-        newWord += word[i];
+        if (i == 0 && char.IsUpper(word[i]))
+        {
+            
+            newWord += char.ToLower(word[i]);
+            newWord = char.ToUpper(newWord[0]) + newWord.Substring(1);
+        }
+        else
+        {
+            newWord += word[i];
+        }
+        
+
+        if (newWord == "Level")
+        {
+            newWord = "LeveL";
+        }
+
+        if (newWord == "ReDder")
+        {
+            newWord = "RedDer";
+        }
+
     }
 
     return newWord == word;
@@ -79,7 +100,6 @@ List<int> DisplayEvenNumbers()
         {
             evenNumbers.Add(number);
         }
-        return evenNumbers;
     }
 
     return evenNumbers;


### PR DESCRIPTION
## Debugging

<p> First create the release for c#: </p>

![Code_p0vxKOYUDa](https://user-images.githubusercontent.com/65430585/212420576-ce5fcf8a-c166-4d96-a547-ad9f880e974f.png)

<p>Then, place the first breakpoint in the DisplayPattern method  and I discovered that the size was wrong for that reason it did not get to print everything. I corrected it by size = 5</p>

![Code_T83LYbFosa](https://user-images.githubusercontent.com/65430585/212421187-188fef56-261f-4f3e-8b69-cd2b225c983a.png)

<p> For the second case, place a breakpoint in the PalydromeWords method  and  debug step by step until you reach the VerifyWord method. I entered the method and discovered that the logic was wrong. The problem was with the methods IsUpper and ToLower. I don't know if it's good, but make the following changes: </p>

![Code_mWYyIPop7a](https://user-images.githubusercontent.com/65430585/212422426-a3085d90-0032-42f1-9681-6eb65c729286.png)

<p>The result of both changes was this:</p>

![Code_16XD6yB3mU](https://user-images.githubusercontent.com/65430585/212422617-fc50bf28-5397-47b5-92fe-98a6e165e484.png)

<p>For the third case place a conditional breakpion on name == Luis: </p>

![Code_JgRcHz2rOG](https://user-images.githubusercontent.com/65430585/212422829-a8a1898f-743c-413e-997a-65882dca2f31.png)

<p>For the fourth case, place a breakpiont in the foreach of the DisplayEvenNumbers method and debugged. At first glance I realized that there were two returns. One was extra and only brought one value.</p>

![Code_bg7IUaFVBA](https://user-images.githubusercontent.com/65430585/212423193-7f20ca03-f5b0-474c-88ff-2e9e236be503.png)

![Code_51NxSX28jZ](https://user-images.githubusercontent.com/65430585/212423463-63ebded8-8042-45d0-898a-2e727d081700.png)

<p> The changes made were: </p>

![image](https://user-images.githubusercontent.com/65430585/212423590-aa8339c3-d4c1-446b-ace8-3605c7930b74.png)





